### PR TITLE
feat(podman): support auto port forwarding

### DIFF
--- a/initrd/config/init.sh
+++ b/initrd/config/init.sh
@@ -50,5 +50,8 @@ fi
 # mount data device to /var/lib/containers
 echo "/dev/vdc /var/lib/containers btrfs defaults 0 0" >> /mnt/overlay/etc/fstab
 
+mkdir -p /mnt/overlay/etc/containers
+echo "qemu" > /mnt/overlay/etc/containers/podman-machine
+
 umount -n /dev /sys /proc
 exec /bin/busybox switch_root /mnt/overlay "${init:-/sbin/init}"


### PR DESCRIPTION
The built-in libpod has automatic port forwarding, but it only enables it when the `/etc/containers/podman-machine` file exists.

Ref: https://github.com/containers/podman/discussions/20757