### PR TITLE
fix(network): occasionally encountering "no route to host" error

### DIFF
--- a/buildroot_external/board/ovm/ready/rootfs-overlay/etc/systemd/system/ready.service
+++ b/buildroot_external/board/ovm/ready/rootfs-overlay/etc/systemd/system/ready.service
@@ -1,6 +1,7 @@
 [Unit]
-Requires=dev-virtio\\x2dports-vsock.device
-After=sshd.service podman.socket
+Requires=dev-virtio\\x2dports-vsock.device sys-devices-virtual-net-tap0.device
+Requires=sshd.service podman.socket gvforwarder.service
+After=sshd.service podman.socket gvforwarder.service sys-devices-virtual-net-tap0.device
 ConditionPathExists=/opt/ready.command
 OnFailure=emergency.target
 OnFailureJobMode=isolate

--- a/buildroot_external/package/gvforwarder/gvforwarder.mk
+++ b/buildroot_external/package/gvforwarder/gvforwarder.mk
@@ -18,7 +18,7 @@ GVFORWARDER_PATCH = \
 
 define GVFORWARDER_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 755 $(@D)/bin/vm $(TARGET_DIR)/usr/bin/gvforwarder
-	$(INSTALL) -D -m 644 $(GVFORWARDER_PKGDIR)/systemd/gvforwader.service \
+	$(INSTALL) -D -m 644 $(GVFORWARDER_PKGDIR)/systemd/gvforwarder.service \
 		$(TARGET_DIR)/etc/systemd/system/
 endef
 

--- a/buildroot_external/package/gvforwarder/systemd/gvforwarder.service
+++ b/buildroot_external/package/gvforwarder/systemd/gvforwarder.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=gvisor-tap-vsock Network Traffic Forwarder
-Requires=podman.service
-After=podman.service
+Requires=network.service
+After=network.service
 StartLimitIntervalSec=0
 ConditionVirtualization=!wsl
 
@@ -9,7 +9,7 @@ ConditionVirtualization=!wsl
 Type=simple
 Restart=on-failure
 ExecStop=/bin/kill -s TERM $MAINPID
-ExecStart=/usr/bin/gvforwarder
+ExecStart=/usr/bin/gvforwarder -iface tap0
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Because the previous `ready` event depended on the `ready.service` service of the virtual machine, which in turn only depended on podman and ssh. Meanwhile, `gvforwarder` only depended on podman. This would cause a concurrency issue: after the `ready` event was sent, `gvforwarder` might not be ready yet, resulting in the host machine being unable to access the virtual machine network.

Now, the `ready` event will only be triggered after `gvforwarder` has created the **tap0** network device.

https://oomol.atlassian.net/browse/OOM-963