### PR TITLE
feat(rootfs): support ssh auth socket forward

### DIFF
--- a/buildroot_external/board/ovm/ssh/rootfs-overlay/usr/lib/systemd/system/ssh-auth.service
+++ b/buildroot_external/board/ovm/ssh/rootfs-overlay/usr/lib/systemd/system/ssh-auth.service
@@ -1,0 +1,15 @@
+[Unit]
+Requires=sshd.service
+After=sshd.service
+Before=ready.service
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+ExecStartPre=/bin/mkdir -p /opt/ovm
+ExecStartPre=/bin/rm -f /opt/ovm/ssh-auth.sock
+ExecStart=socat UNIX-LISTEN:/opt/ovm/ssh-auth.sock,fork VSOCK-CONNECT:2:1028
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
OVM will create an ssh auth sock in the host, then map it to the guest via vsock, so that the container inside can use the host's ssh key.

```shell
podman run -v /opt/ovm:/opt/ovm -e SSH_AUTH_SOCK=/opt/ovm/ssh-auth.sock IMAGE
```

Ref: https://github.com/oomol-lab/ovm-ssh-agent