### PR TITLE
fix(ci): release matrix target incorrect

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         target:
           - initrd
-          - rootfs
+          - applehv-rootfs
           - kernel
         arch:
           - arm64


### PR DESCRIPTION
## Description of Change

<!--- Describe your changes in detail -->

## Required to run CI

- [ ] applehv-rootfs-amd64
- [ ] applehv-rootfs-arm64
- [ ] initrd-amd64
- [ ] initrd-arm64
- [ ] kernel-amd64
- [ ] kernel-arm64
