### PR TITLE
fix(rootfs): ssh auth invalid when container user not is root

### DIFF
--- a/buildroot_external/board/ovm/ssh/rootfs-overlay/usr/lib/systemd/system/ssh-auth.service
+++ b/buildroot_external/board/ovm/ssh/rootfs-overlay/usr/lib/systemd/system/ssh-auth.service
@@ -10,6 +10,7 @@ Restart=always
 ExecStartPre=/bin/mkdir -p /opt/ovm
 ExecStartPre=/bin/rm -f /opt/ovm/ssh-auth.sock
 ExecStart=socat UNIX-LISTEN:/opt/ovm/ssh-auth.sock,fork VSOCK-CONNECT:2:1028
+ExecStartPost=/bin/bash -c "while [ ! -e /opt/ovm/ssh-auth.sock ]; do sleep 0.1; done; /usr/bin/chmod a+rw /opt/ovm/ssh-auth.sock"
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
https://oomol.atlassian.net/browse/OOM-1300

## Description of Change

By default, when the socket file mounted by the virtual machine is mounted to the container, the 'other' permission of the socket file is non-write. This will result in the lack of permission for non-root container users to send messages to the socket.

## Required to run CI

- [ ] applehv-rootfs-amd64
- [ ] applehv-rootfs-arm64
- [ ] initrd-amd64
- [ ] initrd-arm64
- [ ] kernel-amd64
- [ ] kernel-arm64
