### PR TITLE
fix(buildroot): cannot build libffi

### DIFF
--- a/buildroot_external/patches/libffi/3.4.4/1-1-forward-declare-open_temp_exec_file.patch
+++ b/buildroot_external/patches/libffi/3.4.4/1-1-forward-declare-open_temp_exec_file.patch
@@ -1,0 +1,42 @@
+From cbfb9b436ab13e4b4aba867d061e11d7f89a351c Mon Sep 17 00:00:00 2001
+From: serge-sans-paille <sguelton@mozilla.com>
+Date: Wed, 1 Feb 2023 18:09:25 +0100
+Subject: [PATCH] Forward declare open_temp_exec_file
+
+It's defined in closures.c and used in tramp.c.
+Also declare it as an hidden symbol, as it should be.
+---
+ include/ffi_common.h | 4 ++++
+ src/tramp.c          | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/include/ffi_common.h b/include/ffi_common.h
+index 2bd31b03d..c53a79493 100644
+--- a/include/ffi_common.h
++++ b/include/ffi_common.h
+@@ -128,6 +128,10 @@ void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
+    static trampoline. */
+ int ffi_tramp_is_present (void *closure) FFI_HIDDEN;
+ 
++/* Return a file descriptor of a temporary zero-sized file in a
++   writable and executable filesystem. */
++int open_temp_exec_file(void) FFI_HIDDEN;
++
+ /* Extended cif, used in callback from assembly routine */
+ typedef struct
+ {
+diff --git a/src/tramp.c b/src/tramp.c
+index b9d273a1a..c3f4c9933 100644
+--- a/src/tramp.c
++++ b/src/tramp.c
+@@ -39,6 +39,10 @@
+ #ifdef __linux__
+ #define _GNU_SOURCE 1
+ #endif
++
++#include <ffi.h>
++#include <ffi_common.h>
++
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <stdlib.h>


### PR DESCRIPTION
## Description of Change

When using the new version of GCC, it is unable to compile `libffi`.

Error Log:

```sh
../src/tramp.c: In function 'ffi_tramp_get_temp_file':
../src/tramp.c:262:22: error: implicit declaration of function 'open_temp_exec_file' [-Werror=implicit-function-declaration]
  262 |   tramp_globals.fd = open_temp_exec_file ();
      |                      ^~~~~~~~~~~~~~~~~~~
make[5]: *** [Makefile:1323：src/tramp.lo] Error 1
make[4]: *** [Makefile:1395：all-recursive] Error 1
```

Ref: https://github.com/libffi/libffi/pull/764

Thanks, @serge-sans-paille for your patch :)


## Required to run CI

- [x] applehv-rootfs-amd64
- [x] applehv-rootfs-arm64
- [x] initrd-amd64
- [x] initrd-arm64
- [x] kernel-amd64
- [x] kernel-arm64
